### PR TITLE
Add reusable patient selector

### DIFF
--- a/src/app/modules/appointment-calendar/appointment-calendar.component.html
+++ b/src/app/modules/appointment-calendar/appointment-calendar.component.html
@@ -1,13 +1,7 @@
 <h2>Agenda Médica</h2>
 
 <form (ngSubmit)="addAppointment()" class="form">
-  <input
-    type="text"
-    name="patient"
-    placeholder="Paciente"
-    [(ngModel)]="newAppointment.patient"
-    required
-  />
+  <app-patient-selector (select)="onPatientSelected($event)"></app-patient-selector>
   <input
     type="date"
     name="date"

--- a/src/app/modules/appointment-calendar/appointment-calendar.component.ts
+++ b/src/app/modules/appointment-calendar/appointment-calendar.component.ts
@@ -1,23 +1,30 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { DataService, Appointment } from '../../services/data.service';
+import { DataService, Appointment, Patient } from '../../services/data.service';
+import { PatientSelectorComponent } from '../../shared/patient-selector.component';
 
 @Component({
   selector: 'app-appointment-calendar',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, PatientSelectorComponent],
   templateUrl: './appointment-calendar.component.html',
   styleUrl: './appointment-calendar.component.css'
 })
 export class AppointmentCalendarComponent {
   newAppointment: Appointment = { patient: '', date: '', time: '' };
   editingIndex: number | null = null;
+  selectedPatient: Patient | null = null;
 
   currentMonth = new Date();
   selectedDate: string | null = null;
 
   constructor(public data: DataService) {}
+
+  onPatientSelected(patient: Patient) {
+    this.selectedPatient = patient;
+    this.newAppointment.patient = patient.name;
+  }
 
   get appointments() {
     return this.data.appointments;

--- a/src/app/modules/e-prescription/e-prescription.component.html
+++ b/src/app/modules/e-prescription/e-prescription.component.html
@@ -1,13 +1,7 @@
 <h2>Prescripción Médica</h2>
 
 <form (ngSubmit)="addPrescription()" class="form">
-  <input
-    type="text"
-    name="patient"
-    placeholder="Paciente"
-    [(ngModel)]="newPrescription.patient"
-    required
-  />
+  <app-patient-selector (select)="onPatientSelected($event)"></app-patient-selector>
   <input
     type="text"
     name="medication"

--- a/src/app/modules/e-prescription/e-prescription.component.ts
+++ b/src/app/modules/e-prescription/e-prescription.component.ts
@@ -1,20 +1,27 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { DataService, Prescription } from '../../services/data.service';
+import { DataService, Patient, Prescription } from '../../services/data.service';
+import { PatientSelectorComponent } from '../../shared/patient-selector.component';
 
 @Component({
   selector: 'app-e-prescription',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, PatientSelectorComponent],
   templateUrl: './e-prescription.component.html',
   styleUrl: './e-prescription.component.css'
 })
 export class EPrescriptionComponent {
   newPrescription: Prescription = { patient: '', medication: '' };
+  selectedPatient: Patient | null = null;
   editingIndex: number | null = null;
 
   constructor(public data: DataService) {}
+
+  onPatientSelected(patient: Patient) {
+    this.selectedPatient = patient;
+    this.newPrescription.patient = patient.name;
+  }
 
   get prescriptions() {
     return this.data.prescriptions;

--- a/src/app/modules/medical-history/medical-history.component.html
+++ b/src/app/modules/medical-history/medical-history.component.html
@@ -1,13 +1,7 @@
 <h2>Historia Clínica</h2>
 
 <form (ngSubmit)="addEntry()" class="form">
-  <input
-    type="text"
-    name="patient"
-    placeholder="Paciente"
-    [(ngModel)]="newEntry.patient"
-    required
-  />
+  <app-patient-selector (select)="onPatientSelected($event)"></app-patient-selector>
   <input
     type="text"
     name="notes"

--- a/src/app/modules/medical-history/medical-history.component.ts
+++ b/src/app/modules/medical-history/medical-history.component.ts
@@ -1,20 +1,27 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { DataService, HistoryEntry } from '../../services/data.service';
+import { DataService, HistoryEntry, Patient } from '../../services/data.service';
+import { PatientSelectorComponent } from '../../shared/patient-selector.component';
 
 @Component({
   selector: 'app-medical-history',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, PatientSelectorComponent],
   templateUrl: './medical-history.component.html',
   styleUrl: './medical-history.component.css'
 })
 export class MedicalHistoryComponent {
   newEntry: HistoryEntry = { patient: '', notes: '' };
   editingIndex: number | null = null;
+  selectedPatient: Patient | null = null;
 
   constructor(public data: DataService) {}
+
+  onPatientSelected(patient: Patient) {
+    this.selectedPatient = patient;
+    this.newEntry.patient = patient.name;
+  }
 
   get entries() {
     return this.data.histories;

--- a/src/app/modules/patient-management/patient-management.component.html
+++ b/src/app/modules/patient-management/patient-management.component.html
@@ -3,6 +3,13 @@
 <form (ngSubmit)="addPatient()" class="form">
   <input
     type="text"
+    name="id"
+    placeholder="ID"
+    [(ngModel)]="newPatient.id"
+    required
+  />
+  <input
+    type="text"
     name="name"
     placeholder="Nombre"
     [(ngModel)]="newPatient.name"
@@ -34,6 +41,7 @@
 <table class="list" *ngIf="patients.length">
   <thead>
     <tr>
+      <th>ID</th>
       <th>Nombre</th>
       <th>Edad</th>
       <th>Teléfono</th>
@@ -43,6 +51,7 @@
   </thead>
   <tbody>
     <tr *ngFor="let p of patients; let i = index">
+      <td>{{ p.id }}</td>
       <td>{{ p.name }}</td>
       <td>{{ p.age }}</td>
       <td>{{ p.phone }}</td>

--- a/src/app/modules/patient-management/patient-management.component.ts
+++ b/src/app/modules/patient-management/patient-management.component.ts
@@ -11,7 +11,7 @@ import { DataService, Patient } from '../../services/data.service';
   styleUrl: './patient-management.component.css'
 })
 export class PatientManagementComponent {
-  newPatient: Patient = { name: '', age: 0, phone: '', email: '' };
+  newPatient: Patient = { id: '', name: '', age: 0, phone: '', email: '' };
   editingIndex: number | null = null;
 
   constructor(public data: DataService) {}
@@ -32,7 +32,7 @@ export class PatientManagementComponent {
       this.editingIndex = null;
     }
 
-    this.newPatient = { name: '', age: 0, phone: '', email: '' };
+    this.newPatient = { id: '', name: '', age: 0, phone: '', email: '' };
   }
 
   editPatient(i: number) {
@@ -42,6 +42,6 @@ export class PatientManagementComponent {
 
   cancelEdit() {
     this.editingIndex = null;
-    this.newPatient = { name: '', age: 0, phone: '', email: '' };
+    this.newPatient = { id: '', name: '', age: 0, phone: '', email: '' };
   }
 }

--- a/src/app/modules/payments/payments.component.html
+++ b/src/app/modules/payments/payments.component.html
@@ -1,13 +1,7 @@
 <h2>Pagos</h2>
 
 <form (ngSubmit)="addPayment()" class="form">
-  <input
-    type="text"
-    name="patient"
-    placeholder="Paciente"
-    [(ngModel)]="newPayment.patient"
-    required
-  />
+  <app-patient-selector (select)="onPatientSelected($event)"></app-patient-selector>
   <input
     type="number"
     name="amount"

--- a/src/app/modules/payments/payments.component.ts
+++ b/src/app/modules/payments/payments.component.ts
@@ -1,20 +1,27 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { DataService, Payment } from '../../services/data.service';
+import { DataService, Payment, Patient } from '../../services/data.service';
+import { PatientSelectorComponent } from '../../shared/patient-selector.component';
 
 @Component({
   selector: 'app-payments',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, PatientSelectorComponent],
   templateUrl: './payments.component.html',
   styleUrl: './payments.component.css'
 })
 export class PaymentsComponent {
   newPayment: Payment = { patient: '', amount: 0 };
   editingIndex: number | null = null;
+  selectedPatient: Patient | null = null;
 
   constructor(public data: DataService) {}
+
+  onPatientSelected(patient: Patient) {
+    this.selectedPatient = patient;
+    this.newPayment.patient = patient.name;
+  }
 
   get payments() {
     return this.data.payments;

--- a/src/app/services/data.service.ts
+++ b/src/app/services/data.service.ts
@@ -1,6 +1,12 @@
 import { Injectable } from '@angular/core';
 
-export interface Patient { name: string; age: number; phone: string; email: string; }
+export interface Patient {
+  id: string;
+  name: string;
+  age: number;
+  phone: string;
+  email: string;
+}
 export interface Appointment { patient: string; date: string; time: string; }
 export interface HistoryEntry { patient: string; notes: string; }
 export interface Prescription { patient: string; medication: string; }
@@ -10,9 +16,9 @@ export interface InventoryItem { name: string; qty: number; }
 @Injectable({ providedIn: 'root' })
 export class DataService {
   patients: Patient[] = [
-    { name: 'Juan Perez', age: 30, phone: '123456', email: 'juan@example.com' },
-    { name: 'Maria Gomez', age: 25, phone: '234567', email: 'maria@example.com' },
-    { name: 'Carlos Ruiz', age: 40, phone: '345678', email: 'carlos@example.com' },
+    { id: 'P001', name: 'Juan Perez', age: 30, phone: '123456', email: 'juan@example.com' },
+    { id: 'P002', name: 'Maria Gomez', age: 25, phone: '234567', email: 'maria@example.com' },
+    { id: 'P003', name: 'Carlos Ruiz', age: 40, phone: '345678', email: 'carlos@example.com' },
   ];
 
   appointments: Appointment[] = [

--- a/src/app/shared/patient-selector.component.css
+++ b/src/app/shared/patient-selector.component.css
@@ -1,0 +1,25 @@
+.patient-selector {
+  position: relative;
+}
+
+.suggestions {
+  position: absolute;
+  z-index: 10;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  background: white;
+  border: 1px solid #ccc;
+  width: 100%;
+  max-height: 150px;
+  overflow: auto;
+}
+
+.suggestions li {
+  padding: 4px 8px;
+  cursor: pointer;
+}
+
+.suggestions li:hover {
+  background: #efefef;
+}

--- a/src/app/shared/patient-selector.component.html
+++ b/src/app/shared/patient-selector.component.html
@@ -1,0 +1,8 @@
+<div class="patient-selector">
+  <input type="text" [(ngModel)]="query" (input)="onInput()" [placeholder]="placeholder" />
+  <ul class="suggestions" *ngIf="suggestions.length">
+    <li *ngFor="let p of suggestions" (click)="choose(p)">
+      {{ p.name }} ({{ p.id }})
+    </li>
+  </ul>
+</div>

--- a/src/app/shared/patient-selector.component.ts
+++ b/src/app/shared/patient-selector.component.ts
@@ -1,0 +1,35 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { DataService, Patient } from '../services/data.service';
+
+@Component({
+  selector: 'app-patient-selector',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './patient-selector.component.html',
+  styleUrl: './patient-selector.component.css'
+})
+export class PatientSelectorComponent {
+  @Input() placeholder = 'Paciente';
+  @Output() select = new EventEmitter<Patient>();
+
+  query = '';
+  suggestions: Patient[] = [];
+
+  constructor(private data: DataService) {}
+
+  onInput() {
+    const term = this.query.toLowerCase();
+    this.suggestions = this.data.patients.filter(p =>
+      p.name.toLowerCase().includes(term) ||
+      p.id.toLowerCase().includes(term)
+    );
+  }
+
+  choose(patient: Patient) {
+    this.query = `${patient.name}`;
+    this.suggestions = [];
+    this.select.emit(patient);
+  }
+}


### PR DESCRIPTION
## Summary
- add PatientSelectorComponent with autocomplete functionality
- include patient ID in data service
- update patient management to handle patient IDs
- replace patient inputs across forms with new selector

## Testing
- `npm test --silent --yes` *(fails: ng not found)*
- `npx ng build` *(fails: npm registry access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6853da5f7b7883299688711408adbc52